### PR TITLE
Updated to use the new parent content structure.

### DIFF
--- a/app/[instance]/siteHeader.tsx
+++ b/app/[instance]/siteHeader.tsx
@@ -25,9 +25,9 @@ const socket = io("https://api.headlesshost.com");
 export default function SiteHeader({ common, instanceId, clientConfig }: HeaderProps) {
   const [showNav, setShowNav] = useState(false);
   const pathname = usePathname();
-  const { globals = {}, header = { smallLogo: undefined, largeLogo: undefined, links: [] } } = common;
-  const { links = [] } = globals;
-  const { smallLogo, largeLogo, links: headerLinks = [] } = header;
+  const { globals, header } = common;
+  const { links = [] } = globals?.content || {};
+  const { smallLogo, largeLogo, links: headerLinks = [] } = header?.content || {};
 
   useEffect(() => {
     function onStageUpdated(values: any) {

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -1,8 +1,6 @@
 export interface Section {
   id: string;
   type: string;
-  title: string | undefined;
-  content: any;
 }
 
 export interface Heading {
@@ -22,13 +20,17 @@ export interface LinkGroup {
 }
 
 export interface Globals {
-  links?: LinkGroup[];
+  content: {
+    links?: LinkGroup[];
+  };
 }
 
 export interface Header {
-  smallLogo: ImageDetails;
-  largeLogo: ImageDetails;
-  links: NavigationLink[];
+  content: {
+    smallLogo: ImageDetails;
+    largeLogo: ImageDetails;
+    links: NavigationLink[];
+  };
 }
 
 export interface PagedResponse<T> {
@@ -41,15 +43,13 @@ export interface PagedResponse<T> {
 export interface Author {
   id: string;
   cid: string;
-  content: AuthorContent;
-}
-
-export interface AuthorContent {
-  name: string;
-  email: string;
-  role: string;
-  phone: string;
-  image: ImageDetails;
+  content: {
+    name: string;
+    email: string;
+    role: string;
+    phone: string;
+    image: ImageDetails;
+  };
 }
 
 export interface ImageDetails {

--- a/components/leftNav.tsx
+++ b/components/leftNav.tsx
@@ -17,11 +17,11 @@ const LeftNav: React.FC<LeftNavProps> = ({ globals, instanceId }) => {
 
   return (
     <div className="hidden lg:relative lg:block lg:flex-none">
-      {globals?.links && (
+      {globals?.content?.links && (
         <div className="sticky -ml-0.5 w-64 overflow-x-hidden pl-0.5">
           <nav className="text-sm">
             <ul className="space-y-9">
-              {globals?.links.map((item) => (
+              {globals?.content?.links.map((item) => (
                 <li key={item.group}>
                   <h2 className="font-display font-semibold text-slate-900">{item.group}</h2>
                   <ul className="mt-4 space-y-4 border-slate-200">

--- a/components/sections/actionBox.tsx
+++ b/components/sections/actionBox.tsx
@@ -2,7 +2,11 @@ import Link from "next/link";
 import { NavigationLink, Section } from "@/app/lib/types";
 
 interface ActionBoxSection extends Section {
-  link: NavigationLink;
+  content: {
+    title: string;
+    link: NavigationLink;
+    content: string;
+  };
 }
 
 interface ActionBoxProps {
@@ -10,7 +14,7 @@ interface ActionBoxProps {
 }
 
 const ActionBox: React.FC<ActionBoxProps> = ({ section }) => {
-  const { link, title, content } = section;
+  const { link, title, content } = section?.content || {};
   const linkLabel = link?.title;
 
   return (

--- a/components/sections/authorTable.tsx
+++ b/components/sections/authorTable.tsx
@@ -3,7 +3,9 @@ import { getAuthors } from "@/app/lib/api";
 import Image from "next/image";
 
 interface AuthorTableSection extends Section {
-  title: string;
+  content: {
+    title: string;
+  };
 }
 
 interface AuthorTableProps {

--- a/components/sections/cmsImage.tsx
+++ b/components/sections/cmsImage.tsx
@@ -2,8 +2,10 @@ import Image from "next/image";
 import { Section, ImageDetails } from "@/app/lib/types";
 
 interface CmsImageSection extends Section {
-  image: ImageDetails;
-  title: string;
+  content: {
+    title: string;
+    image: ImageDetails;
+  };
 }
 
 interface CmsImageProps {
@@ -11,7 +13,7 @@ interface CmsImageProps {
 }
 
 const CmsImage: React.FC<CmsImageProps> = ({ section }) => {
-  const { title = "Knowledgebase", image = { url: "", alt: "", width: 0, height: 0 } } = section;
+  const { title = "Knowledgebase", image = { url: "", alt: "", width: 0, height: 0 } } = section?.content || {};
   return (
     <div className="mb-14">
       <Image src={image.url} alt={title} width={image.width} height={image.height} className="rounded-md border" />

--- a/components/sections/codeDisplay.tsx
+++ b/components/sections/codeDisplay.tsx
@@ -4,9 +4,11 @@ import { Section } from "@/app/lib/types";
 import { CopyBlock, dracula } from "react-code-blocks";
 
 interface CodeBlockSection extends Section {
-  code: string;
-  language: string;
-  showLineNumbers: boolean;
+  content: {
+    code: string;
+    language: string;
+    showLineNumbers: boolean;
+  };
 }
 
 interface CodeBlockProps {
@@ -14,9 +16,10 @@ interface CodeBlockProps {
 }
 
 const CodeDisplay: React.FC<CodeBlockProps> = ({ section }) => {
+  const { code = "", language = "javascript", showLineNumbers = false } = section?.content || {};
   return (
     <div className="mb-14">
-      <CopyBlock text={section?.code} language={section?.language} showLineNumbers={section?.showLineNumbers} theme={dracula} codeBlock={true} />
+      <CopyBlock text={code} language={language} showLineNumbers={showLineNumbers} theme={dracula} codeBlock={true} />
     </div>
   );
 };

--- a/components/sections/contactForm.tsx
+++ b/components/sections/contactForm.tsx
@@ -4,7 +4,10 @@ import { FormEvent } from "react";
 import { useState } from "react";
 
 interface ContactFormSection extends Section {
-  introduction: string;
+  content: {
+    introduction: string;
+    title: string;
+  };
 }
 
 interface ContactFormProps {
@@ -13,7 +16,7 @@ interface ContactFormProps {
 }
 
 const ContactForm: React.FC<ContactFormProps> = ({ section, siteId }) => {
-  const { introduction, title } = section;
+  const { introduction, title } = section?.content || {};
   const [sent, setSent] = useState(false);
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/components/sections/infoBox.tsx
+++ b/components/sections/infoBox.tsx
@@ -1,8 +1,13 @@
 import { Section } from "@/app/lib/types";
 import React from "react";
+import { ReactNode } from "react";
 
 interface InfoBoxSection extends Section {
-  colour: string;
+  content: {
+    colour: string;
+    content: ReactNode;
+    title: string;
+  };
 }
 
 interface InfoBoxProps {
@@ -10,10 +15,10 @@ interface InfoBoxProps {
 }
 
 const InfoBox: React.FC<InfoBoxProps> = ({ section }) => {
-  const { id, title, content, colour } = section;
+  const { title, content, colour } = section?.content || {};
   return (
     <div className="mb-14">
-      <div className={`rounded-2xl p-6 bg-${colour}-50`} id={id}>
+      <div className={`rounded-2xl p-6 bg-${colour}-50`} id={section.id}>
         <p className="font-display text-xl text-yellow-900 mt-0 mb-2.5">{title}</p>
         <div className={`text-${colour}-800`}>
           <p className="whitespace-pre-wrap">{content}</p>

--- a/components/sections/navLink.tsx
+++ b/components/sections/navLink.tsx
@@ -2,7 +2,9 @@ import { NavigationLink, Section } from "@/app/lib/types";
 import Link from "next/link";
 
 interface NavLinkSection extends Section {
-  link: NavigationLink;
+  content: {
+    link: NavigationLink;
+  };
 }
 
 interface NavLinkProps {
@@ -11,7 +13,7 @@ interface NavLinkProps {
 
 const NavLink: React.FC<NavLinkProps> = ({ section }) => {
   if (!section) return null;
-  const { link } = section;
+  const { link } = section?.content || {};
   const { title, slug, target } = link;
   return (
     <div className="mb-6">

--- a/components/sections/orderedList.tsx
+++ b/components/sections/orderedList.tsx
@@ -1,7 +1,9 @@
 import { Section } from "@/app/lib/types";
 
 interface OrderedList extends Section {
-  items: string[];
+  content: {
+    items: string[];
+  };
 }
 
 interface OrderedListProps {
@@ -10,11 +12,11 @@ interface OrderedListProps {
 
 const OrderedList: React.FC<OrderedListProps> = ({ section }) => {
   if (!section) return null;
-  const { items } = section;
+  const { items } = section?.content || {};
 
   return (
     <ol className="custom-steps mb-14">
-      {items.map((i) => (
+      {items?.map((i) => (
         <li className="text-md text-slate-600" key={i}>
           {i}
         </li>

--- a/components/sections/pageHeader.tsx
+++ b/components/sections/pageHeader.tsx
@@ -5,10 +5,13 @@ import React from "react";
 import { Section } from "@/app/lib/types";
 
 interface PageHeaderSection extends Section {
-  introduction: string | undefined;
-  authorSelect: string;
-  parent: string | undefined;
-  created: string | undefined;
+  content: {
+    introduction: string | undefined;
+    authorSelect: string;
+    parent: string | undefined;
+    created: string | undefined;
+    title: string | undefined;
+  };
 }
 
 interface PageHeaderProps {
@@ -17,7 +20,7 @@ interface PageHeaderProps {
 }
 
 const PageHeader: React.FC<PageHeaderProps> = async ({ section, instanceId }) => {
-  const { introduction, authorSelect, parent, title, created } = section;
+  const { introduction, authorSelect, parent, title, created } = section?.content || {};
   const authors = await getAuthors(instanceId);
   const author = authors?.result?.find((a) => a.cid === authorSelect);
 

--- a/components/sections/standardHeading.tsx
+++ b/components/sections/standardHeading.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { Heading, Section } from "@/app/lib/types";
 
 interface StandardHeadingSection extends Section {
-  heading: Heading;
+  content: {
+    heading: Heading;
+  };
 }
 
 interface StandardHeadingProps {
@@ -10,12 +12,12 @@ interface StandardHeadingProps {
 }
 
 const StandardHeading: React.FC<StandardHeadingProps> = ({ section }) => {
-  const { id, heading } = section;
-  const { headingType, title } = heading;
+  const { heading } = section?.content || {};
+  const { headingType, title } = heading || {};
   const className = `text-${headingType === "h1" ? "3xl" : headingType === "h2" ? "2xl" : headingType === "h3" ? "xl" : headingType === "h4" ? "lg" : "base"}`;
 
   return (
-    <div className={`${className} font-bold mb-8`} id={id}>
+    <div className={`${className} font-bold mb-8`} id={section.id}>
       {title}
     </div>
   );

--- a/components/sections/textBlock.tsx
+++ b/components/sections/textBlock.tsx
@@ -1,12 +1,22 @@
 import React from "react";
 import { Section } from "@/app/lib/types";
 
-interface TextBlockProps {
-  section: Section;
+interface TextBlockSection extends Section {
+  content: {
+    content: string;
+  };
 }
 
-const TextBlock: React.FC<TextBlockProps> = ({ section }) => {
-  return <div className="text-md text-slate-600 whitespace-pre-wrap mb-14">{section.content}</div>;
+interface TextBlockSectionProps {
+  section: TextBlockSection;
+}
+
+const TextBlock: React.FC<TextBlockSectionProps> = ({ section }) => {
+  return (
+    <div className="text-md text-slate-600 whitespace-pre-wrap mb-14 scroll-mt-20" id={section.id}>
+      {section?.content?.content}
+    </div>
+  );
 };
 
 export default TextBlock;

--- a/components/sections/textBlockWithHeader.tsx
+++ b/components/sections/textBlockWithHeader.tsx
@@ -3,8 +3,10 @@ import { Heading, Section } from "@/app/lib/types";
 import StandardHeading from "./standardHeading";
 
 interface TextBlockWithHeaderSection extends Section {
-  heading: Heading;
-  content: string;
+  content: {
+    heading: Heading;
+    content: string;
+  };
 }
 
 interface TextBlockWithHeaderProps {
@@ -12,7 +14,7 @@ interface TextBlockWithHeaderProps {
 }
 
 const TextBlockWithHeader: React.FC<TextBlockWithHeaderProps> = ({ section }) => {
-  const { content } = section;
+  const { content } = section?.content || {};
 
   return (
     <div className="mb-14">

--- a/components/sections/video.tsx
+++ b/components/sections/video.tsx
@@ -2,7 +2,10 @@ import { Section } from "@/app/lib/types";
 import React from "react";
 
 interface VideoSection extends Section {
-  link: string;
+  content: {
+    link: string;
+    title: string;
+  };
 }
 
 interface VideoProps {
@@ -10,9 +13,9 @@ interface VideoProps {
 }
 
 const Video: React.FC<VideoProps> = ({ section }) => {
-  const { id, title, link } = section;
+  const { title, link } = section?.content || {};
   return (
-    <div id={id} className="py-2">
+    <div id={section.id} className="py-2">
       <div id={title} className="aspect-w-16 aspect-h-9" style={{ height: "400px" }}>
         <iframe style={{ width: "100%", height: "100%" }} src={link} allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
       </div>


### PR DESCRIPTION
Updated to latest content structure. All user based content is now nested under a "content" property in sections. This includes page sections, globals, header, and footer.

This is a breaking change